### PR TITLE
update to version 2.225

### DIFF
--- a/jetbrainsmono.nuspec
+++ b/jetbrainsmono.nuspec
@@ -26,7 +26,7 @@ This is a nuspec. It mostly adheres to https://docs.nuget.org/create/Nuspec-Refe
     <!-- version should MATCH as closely as possible with the underlying software -->
     <!-- Is the version a prerelease of a version? https://docs.nuget.org/create/versioning#creating-prerelease-packages -->
     <!-- Note that unstable versions like 0.0.1 can be considered a released version, but it's possible that one can release a 0.0.1-beta before you release a 0.0.1 version. If the version number is final, that is considered a released version and not a prerelease. -->
-    <version>2.002</version>
+    <version>2.225</version>
     <dependencies> 
       <dependency id="chocolatey-font-helpers.extension" version="0.0.2" /> 
     </dependencies>
@@ -53,7 +53,7 @@ This is a nuspec. It mostly adheres to https://docs.nuget.org/create/Nuspec-Refe
     <tags>jetbrains jetbrains-mono mono jetbrainsmono font fontligatures</tags>
     <summary>A typeface made for developers</summary>
     <description>More about font features and design can be found on [its official page](https://www.jetbrains.com/lp/mono/). </description>
-    <releaseNotes>https://github.com/JetBrains/JetBrainsMono/releases/tag/v2.002</releaseNotes>
+    <releaseNotes>https://github.com/JetBrains/JetBrainsMono/releases/tag/v2.225</releaseNotes>
     <!-- =============================== -->      
   </metadata>
   <files>

--- a/tools/chocolateyinstall.ps1
+++ b/tools/chocolateyinstall.ps1
@@ -7,9 +7,9 @@
 $ExitCode = 0
 $PackageName = "JetBrainsMono"
 
-$FontUrl = 'https://github.com/JetBrains/JetBrainsMono/releases/download/v2.002/JetBrainsMono-2.002.zip'
+$FontUrl = 'https://github.com/JetBrains/JetBrainsMono/releases/download/v2.225/JetBrainsMono-2.225.zip'
 $ChecksumType = 'sha256';
-$Checksum = '568FF44A4495773C5D204524E1A8442649B4B53B94E21E1A7D784289C2A19A51';
+$Checksum = '03B2E2C0E3285703A204B6EFBE2D277BF568E0BB53A395E9F4E74E9B77C4AEB2';
 
 $TempInstallPath = Join-Path $Env:Temp $PackageName
 


### PR DESCRIPTION
folder structure changed in `JetBrainsMono-2.225.zip` but the recursive travel gets the same number of .ttf files (28 fonts)